### PR TITLE
Adding HCL files for HPEGL and Morpheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 Tools for using the HPE GreenLake Platform API 
 - Postman collection
 - Automation scripts in bash, PowerShell and Python
+- Terraform HCL configurations

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/README.md
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/README.md
@@ -1,0 +1,62 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_hpegl"></a> [hpegl](#requirement\_hpegl) | >= 0.0.1 |
+| <a name="requirement_morpheus"></a> [morpheus](#requirement\_morpheus) | >= 0.0.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hpegl"></a> [hpegl](#provider\_hpegl) | 0.4.16 |
+| <a name="provider_morpheus"></a> [morpheus](#provider\_morpheus) | 0.11.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hpegl_vmaas_instance.sample_vm](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/resources/vmaas_instance) | resource |
+| [morpheus_group.tf_example_group](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/group) | resource |
+| [morpheus_instance_layout.tf_example_instance_layout](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/instance_layout) | resource |
+| [morpheus_instance_type.tf_example_instance_type](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/instance_type) | resource |
+| [morpheus_node_type.tf_example_node](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/node_type) | resource |
+| [random_integer.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [hpegl_vmaas_cloud_folder.compute_folder](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_cloud_folder) | data source |
+| [hpegl_vmaas_datastore.c_3par](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_datastore) | data source |
+| [hpegl_vmaas_environment.env](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_environment) | data source |
+| [hpegl_vmaas_morpheus_details.morpheus_details](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_morpheus_details) | data source |
+| [hpegl_vmaas_network.blue_segment](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_network) | data source |
+| [hpegl_vmaas_plan.g1_large](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_plan) | data source |
+| [hpegl_vmaas_resource_pool.cl_resource_pool](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_resource_pool) | data source |
+| [morpheus_cloud.cloud](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/data-sources/cloud) | data source |
+| [morpheus_virtual_image.example_virtual_image](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/data-sources/virtual_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud"></a> [cloud](#input\_cloud) | cloud | `string` | n/a | yes |
+| <a name="input_compute_folder"></a> [compute\_folder](#input\_compute\_folder) | computefolder | `string` | n/a | yes |
+| <a name="input_datastore"></a> [datastore](#input\_datastore) | datastore | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | environment | `string` | n/a | yes |
+| <a name="input_group"></a> [group](#input\_group) | group | `string` | n/a | yes |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | image name | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name for the instance | `string` | n/a | yes |
+| <a name="input_layout"></a> [layout](#input\_layout) | layout | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Tenant location | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | network | `string` | n/a | yes |
+| <a name="input_resource_pool"></a> [resource\_pool](#input\_resource\_pool) | resourcepool | `string` | n/a | yes |
+| <a name="input_service_plan"></a> [service\_plan](#input\_service\_plan) | serviceplan | `string` | n/a | yes |
+| <a name="input_space"></a> [space](#input\_space) | space | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/deploy.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/deploy.tf
@@ -1,0 +1,153 @@
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+
+#  Set-up for terraform >= v0.0.1
+terraform {
+  required_providers {
+    hpegl = {
+      source  = "HPE/hpegl"
+      version = ">= 0.0.1"
+    }
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = ">= 0.0.1"
+    }
+  }
+}
+
+# Morpheus
+provider "morpheus" {
+  url          = data.hpegl_vmaas_morpheus_details.morpheus_details.url
+  access_token = data.hpegl_vmaas_morpheus_details.morpheus_details.access_token
+}
+
+# hpegl
+provider "hpegl" {
+  vmaas {
+    location   = var.location
+    space_name = var.space
+  }
+}
+
+data "hpegl_vmaas_morpheus_details" "morpheus_details" {}
+
+# Get Cloud ID
+data "morpheus_cloud" "cloud" {
+  name = var.cloud
+}
+
+data "hpegl_vmaas_datastore" "c_3par" {
+  cloud_id = data.morpheus_cloud.cloud.id
+  name     = var.datastore
+}
+
+data "hpegl_vmaas_network" "blue_segment" {
+  name = var.network
+}
+
+resource "random_integer" "random" {
+  min = 1
+  max = 50000
+}
+
+data "hpegl_vmaas_resource_pool" "cl_resource_pool" {
+  cloud_id = data.morpheus_cloud.cloud.id
+  name     = var.resource_pool
+}
+
+
+data "hpegl_vmaas_plan" "g1_large" {
+  name = var.service_plan
+}
+
+data "hpegl_vmaas_environment" "env" {
+  name = var.environment
+}
+
+data "hpegl_vmaas_cloud_folder" "compute_folder" {
+  cloud_id = data.morpheus_cloud.cloud.id
+  name     = var.compute_folder
+}
+
+data "morpheus_virtual_image" "example_virtual_image" {
+  name = var.image_name
+}
+
+# Create Infrastructure Group
+resource "morpheus_group" "tf_example_group" {
+  name      = var.group
+  code      = var.group
+  location  = "galway"
+  cloud_ids = [data.morpheus_cloud.cloud.id]
+}
+
+# Create Node Type
+resource "morpheus_node_type" "tf_example_node" {
+  name             = "cfe_tf_example_node_type_1"
+  short_name       = "tfexamplenodetype1"
+  labels           = ["demo", "instance", "terraform"]
+  technology       = "vmware"
+  version          = "2.0"
+  category         = "tfexample"
+  virtual_image_id = data.morpheus_virtual_image.example_virtual_image.id
+}
+
+# Create instance type
+resource "morpheus_instance_type" "tf_example_instance_type" {
+  name        = "cfe_tf_example_instance"
+  code        = "cfe_tf_example_instance"
+  description = "Terraform Example Instance Type"
+  labels      = ["demo", "instance", "terraform"]
+  category    = "web"
+  visibility  = "public"
+  featured    = true
+}
+
+# Create Layout
+resource "morpheus_instance_layout" "tf_example_instance_layout" {
+  instance_type_id = morpheus_instance_type.tf_example_instance_type.id
+  name             = "cfe_todo_app_frontend"
+  labels           = ["demo", "layout", "terraform"]
+  version          = "1.0"
+  technology       = "vmware"
+  node_type_ids    = [morpheus_node_type.tf_example_node.id]
+  creatable        = true
+}
+
+# Create a VM from new instance type
+resource "hpegl_vmaas_instance" "sample_vm" {
+  count              = 1
+  name               = "${var.instance_name}-${random_integer.random.result}-${count.index}"
+  cloud_id           = data.morpheus_cloud.cloud.id
+  group_id           = morpheus_group.tf_example_group.id
+  layout_id          = morpheus_instance_layout.tf_example_instance_layout.id
+  plan_id            = data.hpegl_vmaas_plan.g1_large.id
+  instance_type_code = morpheus_instance_type.tf_example_instance_type.code
+  network {
+    id = data.hpegl_vmaas_network.blue_segment.id
+  }
+  environment_code = data.hpegl_vmaas_environment.env.code
+  volume {
+    name         = "root_vol"
+    size         = 30
+    datastore_id = data.hpegl_vmaas_datastore.c_3par.id
+    root         = true
+  }
+  labels = ["sample_vm"]
+  tags = {
+    purpose           = "sample"
+    Division          = "AUK"
+    ResourcePurpose   = "CFE"
+    ResourceContact   = "john.lenihan@hpe.com"
+    APPLICATION       = "Custom Ubuntu"
+    BillingCostCenter = "999"
+    PatchGroup        = "None"
+  }
+  hostname = "${var.instance_name}-${random_integer.random.result}-${count.index}"
+  config {
+    resource_pool_id = data.hpegl_vmaas_resource_pool.cl_resource_pool.id
+    no_agent         = false
+    asset_tag        = "vm_tag"
+    folder_code      = data.hpegl_vmaas_cloud_folder.compute_folder.code
+    create_user      = true
+  }
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/variables.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/One-Cloud-One-Instance/1_location_1_cloud/variables.tf
@@ -1,0 +1,65 @@
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+variable "instance_name" {
+  description = "The name for the instance"
+  type        = string
+}
+
+variable "location" {
+  description = "Tenant location"
+  type        = string
+}
+
+variable "space" {
+  description = "space"
+  type        = string
+}
+
+variable "cloud" {
+  description = "cloud"
+  type        = string
+}
+
+variable "datastore" {
+  description = "datastore"
+  type        = string
+}
+
+variable "network" {
+  description = "network"
+  type        = string
+}
+
+variable "group" {
+  description = "group"
+  type        = string
+}
+
+variable "resource_pool" {
+  description = "resourcepool"
+  type        = string
+}
+
+variable "compute_folder" {
+  description = "computefolder"
+  type        = string
+}
+
+variable "layout" {
+  description = "layout"
+  type        = string
+}
+
+variable "service_plan" {
+  description = "serviceplan"
+  type        = string
+}
+
+variable "environment" {
+  description = "environment"
+  type        = string
+}
+
+variable "image_name" {
+  description = "image name"
+  type        = string
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/README.md
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/README.md
@@ -1,0 +1,74 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_hpegl"></a> [hpegl](#requirement\_hpegl) | = 0.4.14 |
+| <a name="requirement_morpheus"></a> [morpheus](#requirement\_morpheus) | >= 0.0.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hpegl"></a> [hpegl](#provider\_hpegl) | 0.4.14 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_instance_cloud_1"></a> [instance\_cloud\_1](#module\_instance\_cloud\_1) | ../vmaas_instance | n/a |
+| <a name="module_instance_cloud_2"></a> [instance\_cloud\_2](#module\_instance\_cloud\_2) | ../vmaas_instance | n/a |
+| <a name="module_morpheus_artefacts_1"></a> [morpheus\_artefacts\_1](#module\_morpheus\_artefacts\_1) | ../morpheus_artefacts | n/a |
+| <a name="module_morpheus_artefacts_2"></a> [morpheus\_artefacts\_2](#module\_morpheus\_artefacts\_2) | ../morpheus_artefacts | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hpegl_vmaas_morpheus_details.morpheus_details](https://registry.terraform.io/providers/HPE/hpegl/0.4.14/docs/data-sources/vmaas_morpheus_details) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_1"></a> [cloud\_1](#input\_cloud\_1) | cloud 1 | `string` | n/a | yes |
+| <a name="input_cloud_2"></a> [cloud\_2](#input\_cloud\_2) | cloud 2 | `string` | n/a | yes |
+| <a name="input_compute_folder_1"></a> [compute\_folder\_1](#input\_compute\_folder\_1) | computefolder 1 | `string` | n/a | yes |
+| <a name="input_compute_folder_2"></a> [compute\_folder\_2](#input\_compute\_folder\_2) | computefolder 2 | `string` | n/a | yes |
+| <a name="input_datastore_1"></a> [datastore\_1](#input\_datastore\_1) | datastore 1 | `string` | n/a | yes |
+| <a name="input_datastore_2"></a> [datastore\_2](#input\_datastore\_2) | datastore 2 | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | environment | `string` | n/a | yes |
+| <a name="input_group_1"></a> [group\_1](#input\_group\_1) | group 1 | `string` | n/a | yes |
+| <a name="input_group_2"></a> [group\_2](#input\_group\_2) | group 2 | `string` | n/a | yes |
+| <a name="input_image_name_1"></a> [image\_name\_1](#input\_image\_name\_1) | image name 1 | `string` | n/a | yes |
+| <a name="input_image_name_2"></a> [image\_name\_2](#input\_image\_name\_2) | image name 2 | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name for the instance | `string` | n/a | yes |
+| <a name="input_layout_1"></a> [layout\_1](#input\_layout\_1) | layout 1 | `string` | n/a | yes |
+| <a name="input_layout_2"></a> [layout\_2](#input\_layout\_2) | layout 2 | `string` | n/a | yes |
+| <a name="input_location_1"></a> [location\_1](#input\_location\_1) | Tenant location 1 | `string` | n/a | yes |
+| <a name="input_location_2"></a> [location\_2](#input\_location\_2) | Tenant location 2 | `string` | n/a | yes |
+| <a name="input_network_1"></a> [network\_1](#input\_network\_1) | network 1 | `string` | n/a | yes |
+| <a name="input_network_2"></a> [network\_2](#input\_network\_2) | network 2 | `string` | n/a | yes |
+| <a name="input_resource_pool_1"></a> [resource\_pool\_1](#input\_resource\_pool\_1) | resourcepool 1 | `string` | n/a | yes |
+| <a name="input_resource_pool_2"></a> [resource\_pool\_2](#input\_resource\_pool\_2) | resourcepool 2 | `string` | n/a | yes |
+| <a name="input_service_plan_1"></a> [service\_plan\_1](#input\_service\_plan\_1) | serviceplan 1 | `string` | n/a | yes |
+| <a name="input_service_plan_2"></a> [service\_plan\_2](#input\_service\_plan\_2) | serviceplan 2 | `string` | n/a | yes |
+| <a name="input_space"></a> [space](#input\_space) | space | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_ids_cloud_1"></a> [instance\_ids\_cloud\_1](#output\_instance\_ids\_cloud\_1) | List of IDs of the instances created for Cloud 1 |
+| <a name="output_instance_ids_cloud_2"></a> [instance\_ids\_cloud\_2](#output\_instance\_ids\_cloud\_2) | List of IDs of the instances created for Cloud 2 |
+| <a name="output_instance_layout_id_cloud_1"></a> [instance\_layout\_id\_cloud\_1](#output\_instance\_layout\_id\_cloud\_1) | The ID of the instance layout created for Cloud 1 |
+| <a name="output_instance_layout_id_cloud_2"></a> [instance\_layout\_id\_cloud\_2](#output\_instance\_layout\_id\_cloud\_2) | The ID of the instance layout created for Cloud 2 |
+| <a name="output_instance_layout_name_cloud_1"></a> [instance\_layout\_name\_cloud\_1](#output\_instance\_layout\_name\_cloud\_1) | The name of the instance layout created for Cloud 1 |
+| <a name="output_instance_layout_name_cloud_2"></a> [instance\_layout\_name\_cloud\_2](#output\_instance\_layout\_name\_cloud\_2) | The name of the instance layout created for Cloud 2 |
+| <a name="output_instance_names_cloud_1"></a> [instance\_names\_cloud\_1](#output\_instance\_names\_cloud\_1) | List of names of the instances created for Cloud 1 |
+| <a name="output_instance_names_cloud_2"></a> [instance\_names\_cloud\_2](#output\_instance\_names\_cloud\_2) | List of names of the instances created for Cloud 2 |
+| <a name="output_node_type_id_cloud_1"></a> [node\_type\_id\_cloud\_1](#output\_node\_type\_id\_cloud\_1) | The ID of the node type created for Cloud 1 |
+| <a name="output_node_type_id_cloud_2"></a> [node\_type\_id\_cloud\_2](#output\_node\_type\_id\_cloud\_2) | The ID of the node type created for Cloud 2 |
+| <a name="output_node_type_name_cloud_1"></a> [node\_type\_name\_cloud\_1](#output\_node\_type\_name\_cloud\_1) | The name of the node type created for Cloud 1 |
+| <a name="output_node_type_name_cloud_2"></a> [node\_type\_name\_cloud\_2](#output\_node\_type\_name\_cloud\_2) | The name of the node type created for Cloud 2 |
+<!-- END_TF_DOCS -->

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/deploy.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/deploy.tf
@@ -1,0 +1,87 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+#  Set-up for terraform >= v0.0.1
+terraform {
+  required_providers {
+    hpegl = {
+      source  = "HPE/hpegl"
+      version = "= 0.4.14"
+    }
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = ">= 0.0.1"
+    }
+  }
+}
+
+# Hpegl
+provider "hpegl" {
+  vmaas {
+    location   = var.location_1
+    space_name = var.space
+  }
+}
+
+# Morpheus
+provider "morpheus" {
+  url          = data.hpegl_vmaas_morpheus_details.morpheus_details.url
+  access_token = data.hpegl_vmaas_morpheus_details.morpheus_details.access_token
+}
+
+# Morpheus details data source
+data "hpegl_vmaas_morpheus_details" "morpheus_details" {}
+
+# Group and instance type module
+module "morpheus_artefacts_1" {
+  source = "../morpheus_artefacts"
+
+  group      = var.group_1
+  cloud      = var.cloud_1
+  image_name = var.image_name_1
+}
+
+module "morpheus_artefacts_2" {
+  source = "../morpheus_artefacts"
+
+  group      = var.group_2
+  cloud      = var.cloud_2
+  image_name = var.image_name_2
+}
+
+# Cloud 1
+module "instance_cloud_1" {
+  source = "../vmaas_instance"
+
+  instance_name  = var.instance_name
+  datastore      = var.datastore_1
+  network        = var.network_1
+  resource_pool  = var.resource_pool_1
+  compute_folder = var.compute_folder_1
+  layout         = var.layout_1
+  service_plan   = var.service_plan_1
+  environment    = var.environment
+
+  group_id           = module.morpheus_artefacts_1.group_id
+  instance_layout_id = module.morpheus_artefacts_1.instance_layout_id
+  instance_type_code = module.morpheus_artefacts_1.instance_type_code
+  cloud_id           = module.morpheus_artefacts_1.cloud_id
+}
+
+# Cloud 2
+module "instance_cloud_2" {
+  source = "../vmaas_instance"
+
+  instance_name  = var.instance_name
+  datastore      = var.datastore_2
+  network        = var.network_2
+  resource_pool  = var.resource_pool_2
+  compute_folder = var.compute_folder_2
+  layout         = var.layout_2
+  service_plan   = var.service_plan_2
+  environment    = var.environment
+
+  group_id           = module.morpheus_artefacts_2.group_id
+  instance_layout_id = module.morpheus_artefacts_2.instance_layout_id
+  instance_type_code = module.morpheus_artefacts_2.instance_type_code
+  cloud_id           = module.morpheus_artefacts_2.cloud_id
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/outputs.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/outputs.tf
@@ -1,0 +1,60 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+output "instance_ids_cloud_1" {
+  description = "List of IDs of the instances created for Cloud 1"
+  value       = module.instance_cloud_1.instance_id
+}
+
+output "instance_names_cloud_1" {
+  description = "List of names of the instances created for Cloud 1"
+  value       = module.instance_cloud_1.instance_name
+}
+
+output "instance_layout_id_cloud_1" {
+  description = "The ID of the instance layout created for Cloud 1"
+  value       = module.morpheus_artefacts_1.instance_layout_id
+}
+
+output "instance_layout_name_cloud_1" {
+  description = "The name of the instance layout created for Cloud 1"
+  value       = module.morpheus_artefacts_1.instance_layout_name
+}
+
+output "node_type_id_cloud_1" {
+  description = "The ID of the node type created for Cloud 1"
+  value       = module.morpheus_artefacts_1.node_type_id
+}
+
+output "node_type_name_cloud_1" {
+  description = "The name of the node type created for Cloud 1"
+  value       = module.morpheus_artefacts_1.node_type_name
+}
+
+output "instance_ids_cloud_2" {
+  description = "List of IDs of the instances created for Cloud 2"
+  value       = module.instance_cloud_2.instance_id
+}
+
+output "instance_names_cloud_2" {
+  description = "List of names of the instances created for Cloud 2"
+  value       = module.instance_cloud_2.instance_name
+}
+
+output "instance_layout_id_cloud_2" {
+  description = "The ID of the instance layout created for Cloud 2"
+  value       = module.morpheus_artefacts_2.instance_layout_id
+}
+
+output "instance_layout_name_cloud_2" {
+  description = "The name of the instance layout created for Cloud 2"
+  value       = module.morpheus_artefacts_2.instance_layout_name
+}
+
+output "node_type_id_cloud_2" {
+  description = "The ID of the node type created for Cloud 2"
+  value       = module.morpheus_artefacts_2.node_type_id
+}
+
+output "node_type_name_cloud_2" {
+  description = "The name of the node type created for Cloud 2"
+  value       = module.morpheus_artefacts_2.node_type_name
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/variables.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/2_clouds_module_nest/variables.tf
@@ -1,0 +1,115 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+variable "instance_name" {
+  description = "The name for the instance"
+  type        = string
+}
+
+variable "location_1" {
+  description = "Tenant location 1"
+  type        = string
+}
+
+variable "location_2" {
+  description = "Tenant location 2"
+  type        = string
+}
+
+variable "space" {
+  description = "space"
+  type        = string
+}
+
+variable "cloud_1" {
+  description = "cloud 1"
+  type        = string
+}
+
+variable "cloud_2" {
+  description = "cloud 2"
+  type        = string
+}
+
+variable "datastore_1" {
+  description = "datastore 1"
+  type        = string
+}
+
+variable "datastore_2" {
+  description = "datastore 2"
+  type        = string
+}
+
+variable "network_1" {
+  description = "network 1"
+  type        = string
+}
+
+variable "network_2" {
+  description = "network 2"
+  type        = string
+}
+
+variable "group_1" {
+  description = "group 1"
+  type        = string
+}
+
+variable "group_2" {
+  description = "group 2"
+  type        = string
+}
+
+variable "resource_pool_1" {
+  description = "resourcepool 1"
+  type        = string
+}
+
+variable "resource_pool_2" {
+  description = "resourcepool 2"
+  type        = string
+}
+
+variable "compute_folder_1" {
+  description = "computefolder 1"
+  type        = string
+}
+
+variable "compute_folder_2" {
+  description = "computefolder 2"
+  type        = string
+}
+
+variable "layout_1" {
+  description = "layout 1"
+  type        = string
+}
+
+variable "layout_2" {
+  description = "layout 2"
+  type        = string
+}
+
+variable "service_plan_1" {
+  description = "serviceplan 1"
+  type        = string
+}
+
+variable "service_plan_2" {
+  description = "serviceplan 2"
+  type        = string
+}
+
+variable "environment" {
+  description = "environment"
+  type        = string
+}
+
+variable "image_name_1" {
+  description = "image name 1"
+  type        = string
+}
+
+variable "image_name_2" {
+  description = "image name 2"
+  type        = string
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/README.md
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/README.md
@@ -1,0 +1,51 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_morpheus"></a> [morpheus](#provider\_morpheus) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [morpheus_group.tf_example_group](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/group) | resource |
+| [morpheus_instance_layout.tf_example_instance_layout](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/instance_layout) | resource |
+| [morpheus_instance_type.tf_example_instance_type](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/instance_type) | resource |
+| [morpheus_node_type.tf_example_node](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/resources/node_type) | resource |
+| [random_integer.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [morpheus_cloud.cloud](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/data-sources/cloud) | data source |
+| [morpheus_virtual_image.example_virtual_image](https://registry.terraform.io/providers/gomorpheus/morpheus/latest/docs/data-sources/virtual_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud"></a> [cloud](#input\_cloud) | cloud name | `string` | n/a | yes |
+| <a name="input_group"></a> [group](#input\_group) | group name root | `string` | n/a | yes |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | image name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cloud_id"></a> [cloud\_id](#output\_cloud\_id) | The ID of the cloud input |
+| <a name="output_group_code"></a> [group\_code](#output\_group\_code) | The code of the group created |
+| <a name="output_group_id"></a> [group\_id](#output\_group\_id) | The ID of the group created |
+| <a name="output_group_name"></a> [group\_name](#output\_group\_name) | The name of the group created |
+| <a name="output_instance_layout_id"></a> [instance\_layout\_id](#output\_instance\_layout\_id) | The ID of the instance type created |
+| <a name="output_instance_layout_name"></a> [instance\_layout\_name](#output\_instance\_layout\_name) | The name of the instance type created |
+| <a name="output_instance_type_code"></a> [instance\_type\_code](#output\_instance\_type\_code) | The code of the instance type created |
+| <a name="output_instance_type_name"></a> [instance\_type\_name](#output\_instance\_type\_name) | The name of the instance type created |
+| <a name="output_node_type_id"></a> [node\_type\_id](#output\_node\_type\_id) | The ID of the node type created |
+| <a name="output_node_type_name"></a> [node\_type\_name](#output\_node\_type\_name) | The name of the node type created |
+<!-- END_TF_DOCS -->

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/deploy.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/deploy.tf
@@ -1,0 +1,69 @@
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+terraform {
+  required_providers {
+    morpheus = {
+      source = "gomorpheus/morpheus"
+    }
+  }
+}
+
+resource "random_integer" "random" {
+  min = 1
+  max = 50000
+
+  # Keep the random integer unique to the cloud
+  keepers = {
+    cloud = var.cloud
+  }
+}
+
+# Get Cloud ID
+data "morpheus_cloud" "cloud" {
+  name = var.cloud
+}
+
+# Create Infrastructure Group
+resource "morpheus_group" "tf_example_group" {
+  name      = "${var.group}-${random_integer.random.result}"
+  code      = "${var.group}-${random_integer.random.result}"
+  location  = "galway"
+  cloud_ids = [data.morpheus_cloud.cloud.id]
+}
+
+# Create instance type
+resource "morpheus_instance_type" "tf_example_instance_type" {
+  name        = "cfe_tf_example_instance--${random_integer.random.result}"
+  code        = "cfe_tf_example_instance--${random_integer.random.result}"
+  description = "Terraform Example Instance Type"
+  labels      = ["demo", "instance", "terraform"]
+  category    = "web"
+  visibility  = "public"
+  featured    = true
+}
+
+data "morpheus_virtual_image" "example_virtual_image" {
+  name = var.image_name
+}
+
+# Create Node Type
+resource "morpheus_node_type" "tf_example_node" {
+  name             = "cfe_tf_example_node_type--${random_integer.random.result}"
+  short_name       = "tfexamplenodetype-${data.morpheus_virtual_image.example_virtual_image.name}"
+  labels           = ["demo", "instance", "terraform"]
+  technology       = "vmware"
+  version          = "2.0"
+  category         = "tfexample"
+  virtual_image_id = data.morpheus_virtual_image.example_virtual_image.id
+}
+
+# Create Layout
+resource "morpheus_instance_layout" "tf_example_instance_layout" {
+  instance_type_id = morpheus_instance_type.tf_example_instance_type.id
+  name             = "cfe_todo_app_frontend--${random_integer.random.result}"
+  labels           = ["demo", "layout", "terraform"]
+  version          = "1.0"
+  technology       = "vmware"
+  node_type_ids    = [morpheus_node_type.tf_example_node.id]
+  creatable        = true
+}
+

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/outputs.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/outputs.tf
@@ -1,0 +1,50 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+output "instance_layout_id" {
+  description = "The ID of the instance type created"
+  value       = morpheus_instance_layout.tf_example_instance_layout.id
+}
+
+output "instance_layout_name" {
+  description = "The name of the instance type created"
+  value       = morpheus_instance_layout.tf_example_instance_layout.name
+}
+
+output "instance_type_code" {
+  description = "The code of the instance type created"
+  value       = morpheus_instance_type.tf_example_instance_type.code
+}
+
+output "node_type_id" {
+  description = "The ID of the node type created"
+  value       = morpheus_node_type.tf_example_node.id
+}
+
+output "node_type_name" {
+  description = "The name of the node type created"
+  value       = morpheus_node_type.tf_example_node.name
+}
+
+output "instance_type_name" {
+  description = "The name of the instance type created"
+  value       = morpheus_instance_type.tf_example_instance_type.name
+}
+
+output "group_id" {
+  description = "The ID of the group created"
+  value       = morpheus_group.tf_example_group.id
+}
+
+output "group_name" {
+  description = "The name of the group created"
+  value       = morpheus_group.tf_example_group.name
+}
+
+output "group_code" {
+  description = "The code of the group created"
+  value       = morpheus_group.tf_example_group.code
+}
+
+output "cloud_id" {
+  description = "The ID of the cloud input"
+  value       = data.morpheus_cloud.cloud.id
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/variables.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/morpheus_artefacts/variables.tf
@@ -1,0 +1,16 @@
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+variable "cloud" {
+  description = "cloud name"
+  type        = string
+}
+
+
+variable "group" {
+  description = "group name root"
+  type        = string
+}
+
+variable "image_name" {
+  description = "image name"
+  type        = string
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/README.md
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hpegl"></a> [hpegl](#provider\_hpegl) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hpegl_vmaas_instance.sample_vm](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/resources/vmaas_instance) | resource |
+| [random_integer.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [hpegl_vmaas_cloud_folder.compute_folder](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_cloud_folder) | data source |
+| [hpegl_vmaas_datastore.c_3par](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_datastore) | data source |
+| [hpegl_vmaas_environment.env](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_environment) | data source |
+| [hpegl_vmaas_network.blue_segment](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_network) | data source |
+| [hpegl_vmaas_plan.g1_large](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_plan) | data source |
+| [hpegl_vmaas_resource_pool.cl_resource_pool](https://registry.terraform.io/providers/HPE/hpegl/latest/docs/data-sources/vmaas_resource_pool) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_id"></a> [cloud\_id](#input\_cloud\_id) | morpheus cloud id, same name as cloud | `string` | n/a | yes |
+| <a name="input_compute_folder"></a> [compute\_folder](#input\_compute\_folder) | computefolder | `string` | n/a | yes |
+| <a name="input_datastore"></a> [datastore](#input\_datastore) | datastore | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | environment | `string` | n/a | yes |
+| <a name="input_group_id"></a> [group\_id](#input\_group\_id) | group id | `string` | n/a | yes |
+| <a name="input_instance_layout_id"></a> [instance\_layout\_id](#input\_instance\_layout\_id) | instance layout id | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name for the instance | `string` | n/a | yes |
+| <a name="input_instance_type_code"></a> [instance\_type\_code](#input\_instance\_type\_code) | morpheus instance type code | `string` | n/a | yes |
+| <a name="input_layout"></a> [layout](#input\_layout) | layout | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | network | `string` | n/a | yes |
+| <a name="input_resource_pool"></a> [resource\_pool](#input\_resource\_pool) | resourcepool | `string` | n/a | yes |
+| <a name="input_service_plan"></a> [service\_plan](#input\_service\_plan) | serviceplan | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | List of IDs of the instances created |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | List of names of the instances created |
+<!-- END_TF_DOCS -->

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/deploy.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/deploy.tf
@@ -1,0 +1,87 @@
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+terraform {
+  required_providers {
+    hpegl = {
+      source  = "HPE/hpegl"
+    }
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+    }
+  }
+}
+
+resource "random_integer" "random" {
+  min = 1
+  max = 50000
+
+  # Keep the random integer unique to the cloud
+  keepers = {
+   cloud = var.cloud_id
+  }
+}
+
+data "hpegl_vmaas_datastore" "c_3par" {
+  cloud_id = var.cloud_id
+  name     = var.datastore
+}
+
+data "hpegl_vmaas_network" "blue_segment" {
+  name = var.network
+}
+
+data "hpegl_vmaas_resource_pool" "cl_resource_pool" {
+  cloud_id = var.cloud_id
+  name     = var.resource_pool
+}
+
+data "hpegl_vmaas_plan" "g1_large" {
+  name = var.service_plan
+}
+
+data "hpegl_vmaas_environment" "env" {
+  name = var.environment
+}
+
+data "hpegl_vmaas_cloud_folder" "compute_folder" {
+  cloud_id = var.cloud_id
+  name     = var.compute_folder
+}
+
+# Create a VM from new instance type
+resource "hpegl_vmaas_instance" "sample_vm" {
+  count              = 1
+  name               = "${var.instance_name}-${random_integer.random.result}-${count.index}"
+  cloud_id           = var.cloud_id
+  group_id           = var.group_id
+  layout_id          = var.instance_layout_id
+  plan_id            = data.hpegl_vmaas_plan.g1_large.id
+  instance_type_code = var.instance_type_code
+  network {
+    id = data.hpegl_vmaas_network.blue_segment.id
+  }
+  environment_code = data.hpegl_vmaas_environment.env.code
+  volume {
+    name         = "root_vol"
+    size         = 30
+    datastore_id = data.hpegl_vmaas_datastore.c_3par.id
+    root         = true
+  }
+  labels = ["sample_vm"]
+  tags = {
+    purpose = "sample"
+    Division = "AUK"
+    ResourcePurpose = "CFE"
+    ResourceContact = "john.lenihan@hpe.com"
+    APPLICATION = "Custom Ubuntu"
+    BillingCostCenter = "999"
+    PatchGroup = "None"
+  }
+  hostname = "${var.instance_name}-${random_integer.random.result}-${count.index}"
+  config {
+    resource_pool_id = data.hpegl_vmaas_resource_pool.cl_resource_pool.id
+    no_agent         = false
+    asset_tag        = "vm_tag"
+    folder_code      = data.hpegl_vmaas_cloud_folder.compute_folder.code
+    create_user      = true
+  }
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/outputs.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/outputs.tf
@@ -1,0 +1,10 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+output "instance_id" {
+  description = "List of IDs of the instances created"
+  value       = one(hpegl_vmaas_instance.sample_vm[*].id)
+}
+
+output "instance_name" {
+  description = "List of names of the instances created"
+  value       = one(hpegl_vmaas_instance.sample_vm[*].name)
+}

--- a/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/variables.tf
+++ b/Terraform/HPEGL-Morpheus-PCE-VMaaS/One-Location/Two-Clouds-Two-Instances/vmaas_instance/variables.tf
@@ -1,0 +1,60 @@
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+variable "instance_name" {
+  description = "The name for the instance"
+  type        = string
+}
+
+variable "datastore" {
+  description = "datastore"
+  type        = string
+}
+
+variable "network" {
+  description = "network"
+  type        = string
+}
+
+variable "instance_type_code" {
+  description = "morpheus instance type code"
+  type        = string
+}
+
+variable "instance_layout_id" {
+  description = "instance layout id"
+  type        = string
+}
+
+variable "group_id" {
+  description = "group id"
+  type        = string
+}
+
+variable "cloud_id" {
+    description = "morpheus cloud id, same name as cloud"
+    type        = string
+}
+
+variable "resource_pool" {
+  description = "resourcepool"
+  type        = string
+}
+
+variable "compute_folder" {
+  description = "computefolder"
+  type        = string
+}
+
+variable "layout" {
+  description = "layout"
+  type        = string
+}
+
+variable "service_plan" {
+  description = "serviceplan"
+  type        = string
+}
+
+variable "environment" {
+  description = "environment"
+  type        = string
+}


### PR DESCRIPTION
These are associated with a Blog post on how to use the HPEGL and Morpheus Terraform Providers in concert to create and manage PCE VMaaS VM Instances.  READMEs generated by terraform-docs are included in each HCL directory.